### PR TITLE
[FIX] UI: Resolve Input Text Visibility and Button Contrast Issues

### DIFF
--- a/apps/trajectory2/src/app/account/account-form.tsx
+++ b/apps/trajectory2/src/app/account/account-form.tsx
@@ -60,7 +60,7 @@ export default function AccountForm({ user }: { user: User }) {
               type="email"
               value={user.email || ''}
               disabled
-              className="bg-elev-1"
+              className="bg-elev-1 text-white border-[var(--border-default)]"
             />
             <p className="text-xs text-muted">
               Your email address is verified and cannot be changed
@@ -79,7 +79,7 @@ export default function AccountForm({ user }: { user: User }) {
                 day: 'numeric'
               })}
               disabled
-              className="bg-elev-1"
+              className="bg-elev-1 text-white border-[var(--border-default)]"
             />
           </div>
         </CardContent>

--- a/apps/trajectory2/src/app/login/page.tsx
+++ b/apps/trajectory2/src/app/login/page.tsx
@@ -201,7 +201,7 @@ function LoginContent() {
                     autoComplete="email"
                     required
                     placeholder="you@example.com"
-                    className="bg-elev-1"
+                    className="bg-elev-1 text-white border-[var(--border-default)] placeholder:text-gray-400"
                   />
                 </div>
 
@@ -216,7 +216,7 @@ function LoginContent() {
                     autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
                     required
                     placeholder="••••••••"
-                    className="bg-elev-1"
+                    className="bg-elev-1 text-white border-[var(--border-default)] placeholder:text-gray-400"
                   />
                   {mode === 'signup' && (
                     <p className="text-xs text-muted">

--- a/apps/trajectory2/src/components/AuthModal.tsx
+++ b/apps/trajectory2/src/components/AuthModal.tsx
@@ -121,7 +121,7 @@ export default function AuthModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md bg-white">
         <DialogHeader>
           <DialogTitle className="text-2xl font-bold bg-gradient-to-r from-orange-500 to-red-600 bg-clip-text text-transparent">
             {title}

--- a/apps/trajectory2/src/components/Navigation.tsx
+++ b/apps/trajectory2/src/components/Navigation.tsx
@@ -135,14 +135,14 @@ export default function Navigation() {
                       <User className="w-4 h-4" />
                       Account
                     </Link>
-                    <Button onClick={handleSignOut} variant="outline" size="sm">
+                    <Button onClick={handleSignOut} variant={isDarkPage ? "outline" : "outlineLight"} size="sm">
                       <LogOut className="w-4 h-4 mr-2" />
                       Sign Out
                     </Button>
                   </>
                 ) : (
                   <>
-                    <Button asChild variant="outline" size="sm">
+                    <Button asChild variant={isDarkPage ? "outline" : "outlineLight"} size="sm">
                       <Link href="/login">Sign In</Link>
                     </Button>
                     <Button asChild>
@@ -241,7 +241,7 @@ export default function Navigation() {
                         Account
                       </Link>
                       <div className="px-3 pt-2">
-                        <Button onClick={handleSignOut} variant="outline" className="w-full">
+                        <Button onClick={handleSignOut} variant={isDarkPage ? "outline" : "outlineLight"} className="w-full">
                           <LogOut className="w-4 h-4 mr-2" />
                           Sign Out
                         </Button>
@@ -250,7 +250,7 @@ export default function Navigation() {
                   ) : (
                     <>
                       <div className="px-3 pt-2 space-y-2">
-                        <Button asChild variant="outline" className="w-full">
+                        <Button asChild variant={isDarkPage ? "outline" : "outlineLight"} className="w-full">
                           <Link href="/login" onClick={() => setIsMenuOpen(false)}>
                             Sign In
                           </Link>

--- a/apps/trajectory2/src/components/raffle/TransformationCommitment.tsx
+++ b/apps/trajectory2/src/components/raffle/TransformationCommitment.tsx
@@ -91,7 +91,7 @@ export default function TransformationCommitment() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
         >
-          <Card className="border-2 border-sunset/20 shadow-2xl">
+          <Card className="border-2 border-sunset/20 shadow-2xl bg-white">
             <CardHeader className="text-center pb-8 pt-10">
               <motion.div
                 className="w-20 h-20 bg-gradient-to-br from-sunset to-sunset-dark rounded-full flex items-center justify-center mx-auto mb-4"

--- a/apps/trajectory2/src/components/ui/button.tsx
+++ b/apps/trajectory2/src/components/ui/button.tsx
@@ -15,6 +15,8 @@ const buttonVariants = cva(
           "bg-red-900 text-red-50 shadow-sm hover:bg-red-800",
         outline:
           "border border-[var(--border-default)] bg-transparent shadow-sm hover:bg-[var(--bg-elev-2)] hover:border-[var(--border-hover)]",
+        outlineLight:
+          "border border-gray-300 bg-white/50 text-gray-700 shadow-sm hover:bg-gray-50 hover:border-gray-400",
         secondary:
           "bg-[var(--bg-elev-2)] text-[var(--text-primary)] shadow-sm hover:bg-[var(--bg-elev-3)]",
         ghost: "hover:bg-[var(--bg-elev-2)] hover:text-[var(--text-primary)]",

--- a/apps/trajectory2/src/components/ui/input.tsx
+++ b/apps/trajectory2/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-9 w-full rounded-md border border-gray-300 px-3 py-1 text-base text-gray-900 shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-gold)] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}

--- a/apps/trajectory2/src/components/ui/textarea.tsx
+++ b/apps/trajectory2/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[60px] w-full rounded-md border border-gray-300 px-3 py-2 text-base text-gray-900 shadow-sm placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-gold)] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       ref={ref}


### PR DESCRIPTION
## Summary
Fixed critical visibility issues affecting user experience across the application:
- Sign In buttons were transparent on light pages
- Input/textarea text was completely invisible due to undefined CSS variables
- Inconsistent button contrast across different page backgrounds

## Changes
- **Fixed Input/Textarea Components**: Replaced undefined CSS variables (`border-input`, `text-foreground`, etc.) with explicit Tailwind classes for proper text visibility
- **Added outlineLight Button Variant**: New variant for buttons on light backgrounds with proper contrast
- **Updated Navigation**: Sign In/Out buttons now use conditional variants based on `isDarkPage`
- **Fixed Dark Background Inputs**: Login and account pages now have visible text with proper contrast
- **Ensured Component Backgrounds**: Added explicit backgrounds to Dialog and Card components

## Testing
- ✅ Input text visible on login page (dark background)
- ✅ Input text visible on account page (dark background)
- ✅ Input text visible in AuthModal (light background)
- ✅ Input text visible in raffle form (light background)
- ✅ Sign In button visible on home page (dark)
- ✅ Sign In button visible on all other pages (light)
- ✅ All hover states work correctly
- ✅ No linter errors

## Root Cause
Shadcn/ui components were copied with CSS variable references (`border-input`, `text-foreground`, `ring-ring`, etc.) that were never defined in the project's design system. The project uses custom CSS variables (`--brand-gold`, `--bg-elev-1`, etc.) but the input components referenced completely different variables.