### PR TITLE
feat(config): Add feature flags system for runtime control

### DIFF
--- a/apps/trajectory2/src/lib/config.ts
+++ b/apps/trajectory2/src/lib/config.ts
@@ -9,6 +9,13 @@ export interface FeatureFlags {
   GIVEAWAY_ENABLED: boolean;
 }
 
+/**
+ * Feature flags for controlling application features at runtime
+ */
+export const FEATURE_FLAGS: FeatureFlags = {
+  GIVEAWAY_ENABLED: false,
+};
+
 export const THINKIFIC_COURSE_URL = 
   process.env.NEXT_PUBLIC_THINKIFIC_COURSE_URL || 
   'https://jean-s-site-8b39.thinkific.com/products/courses/trajectory';


### PR DESCRIPTION
Add centralized feature flag system to control feature visibility at runtime.

## Changes
- Added `FeatureFlags` interface for type safety
- Added `FEATURE_FLAGS` constant with `GIVEAWAY_ENABLED: false`
- Added JSDoc documentation

## Purpose
This provides infrastructure to hide/show the giveaway feature without code deletion.

## Micro-commits
1. `feat(config): add FeatureFlags interface`
2. `feat(config): add FEATURE_FLAGS constant with GIVEAWAY_ENABLED disabled`

## Next Steps
Will be used in Phase 1.3 to conditionally hide giveaway from homepage.