### PR TITLE
refactor(homepage): Hide giveaway section using feature flag

### DIFF
--- a/apps/trajectory2/src/app/page.tsx
+++ b/apps/trajectory2/src/app/page.tsx
@@ -182,8 +182,8 @@ export default function Home() {
                   Trajectory
                 </h1>
 
-                {/* Grand Opening Giveaway */}
-                <GiveawayHeroSection />
+                {/* Grand Opening Giveaway - Hidden via feature flag */}
+                {FEATURE_FLAGS.GIVEAWAY_ENABLED && <GiveawayHeroSection />}
 
                 <h2 className="text-3xl md:text-4xl font-light text-gold mb-8 h-16 flex items-center">
                   <span>Command your </span>


### PR DESCRIPTION
Hide giveaway section from homepage using the FEATURE_FLAGS system.

## Changes
- Imported `FEATURE_FLAGS` from config
- Wrapped `GiveawayHeroSection` in conditional rendering
- Updated comment to indicate feature flag control

## Behavior
- Giveaway section is now **hidden** from users (GIVEAWAY_ENABLED = false)
- Can be re-enabled by setting `FEATURE_FLAGS.GIVEAWAY_ENABLED = true`
- All giveaway code, API routes, and admin dashboard remain intact

## Micro-commits
1. `refactor(homepage): import FEATURE_FLAGS from config`
2. `refactor(homepage): hide giveaway section using FEATURE_FLAGS.GIVEAWAY_ENABLED`

## Testing
- [x] Homepage renders without giveaway section
- [x] No console errors
- [x] Layout remains intact

## Related
- Depends on PR #31 (merged)